### PR TITLE
Adding support for building libksi on Mac OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,84 @@
+# http://www.gnu.org/software/automake
+
+GNUMakefile.in
+config.h.in
+Makefile.in
+/m4
+
+# http://www.gnu.org/software/autoconf
+
+/autom4te.cache
+/aclocal.m4
+/compile
+/configure
+/depcomp
+/install-sh
+/missing
+/stamp-h1
+/config
+config.status
+config.log
+
+GNUMakefile
+config.h
+
+.deps
+libksi.pc
+src/ksi/stamp-h1
+
+libtool
+
+#Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+
+# Binaries and log files
+ksi_verify.log
+src/example/.libs/
+src/example/ksi_extend
+src/example/ksi_multisig_add
+src/example/ksi_multisig_extend
+src/example/ksi_pubfiledump
+src/example/ksi_sign
+src/example/ksi_sign_aggr
+src/example/ksi_verify
+src/example/ksi_verify_pub
+src/ksi/.libs/
+test.log
+test/.dirstamp
+test/.libs/
+test/cutest/.dirstamp
+test/parse-benchmark
+test/resigner
+test/runner
+test/serialize-benchmark
+testsuite-xunit.xml

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,7 @@ if test -z "$with_cafile" ; then
             /etc/pki/tls/certs/ca-bundle.trust.crt \
             /usr/share/ssl/certs/ca-bundle.trust.crt \
             /usr/local/share/certs/ca-root.trust.crt \
+            /usr/local/etc/openssl/cert.pem \
             /etc/ssl/cert.pem ; do
         if test -f "$cafile" ; then
             with_cafile="$cafile"


### PR DESCRIPTION
Mac OSX doesn't use OpenSSL for it certificate bundles. Typically ports of applications and libraries from other Unix flavors use the OpenSSL library that can be installed with [homebrew](http://brew.sh). I updated the configure.ac to look for the certificate bundle installed by homebrew. Also, I added some .gitignores to make working with git easier.
