### PR TITLE
Enable clean builds in Fedora COPR

### DIFF
--- a/redhat/libksi.spec.in
+++ b/redhat/libksi.spec.in
@@ -53,7 +53,7 @@ Guardtime's Keyless Signature Service.
 
 %prep
 %setup
-autoreconf -iv
+autoreconf -ifv
 
 %build
 %configure


### PR DESCRIPTION
In order to build libksi on el6, 7, f22, 23, and 24, accommodating all those environments, we need to use the `autoreconf -f` switch to force it to ignore various files generated by a local tar ball build using `make dist` which are included in the tar ball itself.

An alternative would be to create a tar ball from the original source tree, or exclude all the build environment generated files.

It seems the `-f` option is the simplest.
